### PR TITLE
replace lookups in Hiera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+* Replace lookups() in Hiera
+
+### Fixed
+* Fix missing values when using resource-like class declaration and Hiera
+
 ## Release 1.0.0
 initial version
+
+[Unreleased]: https://github.com/markt-de/puppet-ssp/compare/1.0.0...HEAD

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,7 +1,7 @@
 ---
 ssp::config: {}
 
-ssp::config_file: "%{lookup('ssp::installroot')}/self-service-password-%{lookup('ssp::version')}/conf/config.inc.local.php"
+ssp::config_file: 'conf/config.inc.local.php'
 ssp::config_manage: true
 ssp::config_mode: "0600"
 ssp::config_template: "ssp/config.inc.local.epp"
@@ -10,7 +10,7 @@ ssp::edition: 'oss'
 ssp::group: 'apache'
 ssp::installroot: '/opt'
 ssp::manage_symlink: true
-ssp::mirror: "https://github.com/ltb-project/self-service-password/archive/refs/tags/v%{lookup('ssp::version')}.tar.gz"
+ssp::mirror: 'https://github.com/ltb-project/self-service-password/archive/refs/tags/v%s.tar.gz'
 ssp::symlink_name: 'ssp'
 ssp::user: 'apache'
 ssp::version: ~

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,7 @@
 # 
 class ssp::config {
   if $ssp::config_manage {
-    file { $ssp::config_file:
+    file { "${ssp::installroot}/self-service-password-${ssp::version}/${ssp::config_file}":
       ensure  => file,
       mode    => $ssp::config_mode,
       content => epp($ssp::config_template),

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,7 +6,7 @@ class ssp::install {
   include 'archive'
 
   $archive_name = "self-service-password-${ssp::version}.tar.gz"
-  $download_url = $ssp::mirror
+  $download_url = sprintf($ssp::mirror, $ssp::version)
   $install_dir = "${ssp::installroot}/self-service-password-${ssp::version}"
 
   # Archive unzip


### PR DESCRIPTION
Using `lookup` in Hiera seemed like a good approach. Unfortunately, this does not work when using both resource-like class declaration _and_ Hiera at the same time (e.g. when using the roles & profiles pattern). This would result in some values being not properly set.

So this PR removes all `lookup` calls from Hiera and moves the logic to the manifests.